### PR TITLE
add support for --check/--diff to:

### DIFF
--- a/ansible/modules/hashivault/hashivault_auth_method.py
+++ b/ansible/modules/hashivault/hashivault_auth_method.py
@@ -95,9 +95,17 @@ def hashivault_auth_method(module):
     except Exception:
         pass
 
+    diff = dict()
+    diff_header = '/'.join(['sys', 'auth', mount_point])
     if state == 'enabled' and not exists:
         changed = True
         create = True
+        diff.update(
+            before=dict(),
+            before_header='(new auth method)',
+            after=config,
+            after_header=diff_header,
+        )
     elif state == 'disabled' and exists:
         changed = True
     elif exists and state == 'enabled':
@@ -107,9 +115,17 @@ def hashivault_auth_method(module):
                 changed = True
         if not changed:
             changed = is_state_changed(config, current_state)
+        after = dict(**DEFAULT_CONFIG)
+        after.update(config)
+        diff.update(
+            before=current_state,
+            before_header=diff_header,
+            after=after,
+            after_header=diff_header,
+        )
 
     if module.check_mode:
-        return {'changed': changed, 'created': create, 'state': state}
+        return {'changed': changed, 'created': create, 'state': state, 'diff': diff}
     if not changed:
         return {'changed': changed, 'created': False, 'state': state}
 
@@ -121,7 +137,7 @@ def hashivault_auth_method(module):
     if state == 'disabled':
         client.sys.disable_auth_method(path=mount_point)
 
-    return {'changed': changed, 'created': create}
+    return {'changed': changed, 'created': create, 'diff': diff}
 
 
 if __name__ == '__main__':

--- a/ansible/modules/hashivault/hashivault_aws_secret_engine_config.py
+++ b/ansible/modules/hashivault/hashivault_aws_secret_engine_config.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+from ansible.module_utils.hashivault import hashivault_argspec
+from ansible.module_utils.hashivault import hashivault_auth_client
+from ansible.module_utils.hashivault import hashivault_init
+from ansible.module_utils.hashivault import hashiwrapper
+from hvac.exceptions import InvalidPath
+
+ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
+DOCUMENTATION = '''
+---
+module: hashivault_aws_secret_engine_config
+version_added: "pure_ci-1.0.0"
+short_description: Hashicorp Vault aws secret engine config
+description:
+    - Module to configure an aws secret engine via variables or json file
+options:
+    mount_point:
+        description:
+            - name of the secret engine mount name.
+        default: aws
+    lease:
+        description:
+            - lease config.  must be a dict
+extends_documentation_fragment: hashivault
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_aws_secret_engine_config:
+        mount_point: aws
+        lease:
+          lease: 24h0m0s
+          lease_max: 24h0m0s
+
+    - hashivault_aws_secret_engine_config:
+        mount_point: aws-foo
+        lease:
+          lease_max: 12h0m0s
+'''
+
+
+def main():
+    argspec = hashivault_argspec()
+    argspec['mount_point'] = dict(required=False, type='str', default='aws')
+    argspec['lease'] = dict(required=True, type='dict')
+
+    module = hashivault_init(argspec, supports_check_mode=True)
+    result = hashivault_aws_secret_engine_config(module)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+@hashiwrapper
+def hashivault_aws_secret_engine_config(module):
+    params = module.params
+    client = hashivault_auth_client(params)
+    changed = False
+    lease = params.get('lease')
+    mount_point = params.get('mount_point').strip('/')
+    desired_state = lease
+
+    missing = [k for k in ['lease', 'lease_max'] if k not in lease]
+    if missing:
+        return {
+            'rc': 1,
+            'failed': True,
+            'msg': u"missing key(s) in lease: " + ', '.join(missing),
+        }
+
+    try:
+        current_state = client.secrets.aws.read_lease_config(mount_point)['data']
+    except InvalidPath:
+        current_state = {}
+
+    if current_state != desired_state:
+        diff_header='/'.join([mount_point, 'config', 'lease'])
+        diff = dict(
+            before=current_state,
+            before_header=diff_header if current_state else '(absent)',
+            after=desired_state,
+            after_header=diff_header,
+        )
+        if not module.check_mode:
+            client.secrets.aws.configure_lease(mount_point=mount_point, **lease)
+        return {'changed': True, 'diff': diff}
+
+    return {'changed': False}
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/modules/hashivault/hashivault_aws_secret_engine_role.py
+++ b/ansible/modules/hashivault/hashivault_aws_secret_engine_role.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python
+from ansible.module_utils.hashivault import hashivault_argspec
+from ansible.module_utils.hashivault import hashivault_auth_client
+from ansible.module_utils.hashivault import hashivault_init
+from ansible.module_utils.hashivault import hashiwrapper
+from hvac.exceptions import InvalidPath
+import json
+
+ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
+DOCUMENTATION = '''
+---
+module: hashivault_aws_secret_engine_role
+version_added: "3.17.6"
+short_description: Hashicorp Vault aws secret engine role
+description:
+    - Module to define a Aws role that vault can generate dynamic credentials for vault
+options:
+    mount_point:
+        description:
+            - name of the secret engine mount name.
+        default: aws
+    name:
+        description:
+            - name of the role in vault
+    credential_type:
+        type: string
+        choices: ["iam_user", "assumed_role", "federation_token"]
+        description:
+            - credential type
+    policy_document:
+        type: dict
+        description:
+            - policy document
+    policy_document_file:
+        type: string
+        description:
+            - path to policy document JSON file
+    default_sts_ttl:
+        description:
+            - default TTL for STS credentials
+    max_sts_ttl:
+        description:
+            - max TTL for STS credentials
+    role_arns:
+        description:
+            - List of ARNs of the AWS roles this Vault role is allowed to assume. Required when credential_type is assumed_role and prohibited otherwise.
+    policy_arns:
+        description:
+            - List of ARNs of the AWS managed policies to be attached to IAM users when they are requested. Valid only when credential_type is iam_user, or legacy_params is True. When credential_type is iam_user, at least one of policy_arns or policy_document must be specified.
+    legacy_params:
+        type: bool
+        description:
+            - Flag to send legacy (Vault versions < 0.11.0) parameters in the request.  If true, only policy_document, policy_document_file, and policy_arns are valid.
+
+
+extends_documentation_fragment: hashivault
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_aws_secret_engine_role:
+        name: contributor-role
+        policy_document_file: path/to/policy.json
+'''
+
+
+def main():
+    argspec = hashivault_argspec()
+    argspec['name'] = dict(required=True, type='str')
+    argspec['mount_point'] = dict(required=False, type='str', default='aws')
+    argspec['credential_type'] = dict(required=True, type='str',
+                                      choices=['iam_user', 'assumed_role', 'federation_token',
+                                               # when legacy_params=True
+                                               'iam_user,federation_token'])
+    argspec['policy_document'] = dict(required=False, type='dict')
+    argspec['policy_document_file'] = dict(required=False, type='str')
+    argspec['default_sts_ttl'] = dict(required=False, type='str', default=None)
+    argspec['max_sts_ttl'] = dict(required=False, type='str', default=None)
+    argspec['role_arns'] = dict(required=False, type='list')
+    argspec['policy_arns'] = dict(required=False, type='list')
+    argspec['legacy_params'] = dict(required=False, type='bool', default=False)
+    mutually_exclusive = [['policy_document', 'policy_document_file']]
+    required_if = [
+        ('credential_type', 'assumed_role', ['role_arns']),
+
+        # when credential_type == 'iam_user', at least one of [policy_arns, policy_document,
+        # policy_document_file] is required
+        ('credential_type', 'iam_user',
+             ['policy_arns', 'policy_document', 'policy_document_file'], True),
+    ]
+
+    module = hashivault_init(argspec, supports_check_mode=True,
+                             mutually_exclusive=mutually_exclusive, required_if=required_if)
+    result = hashivault_aws_secret_engine_role(module)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+FORBIDDEN_IF_IAM_USER = ['default_sts_ttl', 'max_sts_ttl']
+
+
+@hashiwrapper
+def hashivault_aws_secret_engine_role(module):
+    params = module.params
+    client = hashivault_auth_client(params)
+    name = params.get('name').strip('/')
+    mount_point = params.get('mount_point').strip('/')
+    credential_type = params.get('credential_type')
+
+    policy_document = params.get('policy_document')
+    policy_document_file = params.get('policy_document_file')
+    # if policy_document_file is set, set policy_document to contents
+    # else assume policy_document is set and use that value
+    if policy_document_file:
+        policy_document = json.loads(open(policy_document_file, 'r').read())
+
+    legacy_params = params.get('legacy_params')
+
+    desired_state = dict()
+    desired_state['credential_type'] = credential_type
+    desired_state['policy_document'] = policy_document
+    desired_state['default_sts_ttl'] = params.get('default_sts_ttl')
+    desired_state['max_sts_ttl'] = params.get('max_sts_ttl')
+    desired_state['role_arns'] = params.get('role_arns')
+    desired_state['policy_arns'] = params.get('policy_arns')
+
+    if not legacy_params:
+        if desired_state['role_arns'] and credential_type != 'assumed_role':
+            return {
+                'failed': True,
+                'rc': 1,
+                'msg': 'role_arns forbidden when credential_type != "assumed_role"',
+            }
+
+        if desired_state['policy_arns'] and credential_type != 'iam_user':
+            return {
+                'failed': True,
+                'rc': 1,
+                'msg': 'role_arns forbidden when credential_type != "iam_user"',
+            }
+
+        if credential_type == 'iam_user':
+            for param in FORBIDDEN_IF_IAM_USER:
+                if desired_state[param]:
+                    return {
+                        'failed': True,
+                        'rc': 1,
+                        'msg': '{} forbidden when credential_type == "{}"'.format(
+                            param,
+                            credential_type,
+                        ),
+                    }
+
+    try:
+        existing_roles = client.secrets.aws.list_roles(mount_point=mount_point)
+        existing = name in existing_roles['data']['keys']
+    except InvalidPath:
+        existing = False
+
+    if existing:
+        # check if role content == desired
+        current = client.secrets.aws.read_role(name=name, mount_point=mount_point)['data']
+
+        # fixups to the "current" object for diff purposes
+        if 'policy_document' in current:
+            try:
+                current['policy_document'] = json.loads(current['policy_document'])
+            except ValueError:
+                # just treat it as a diff
+                pass
+
+        if 'credential_types' in current:
+            current['credential_type'] = ','.join(current.pop('credential_types'))
+
+        if legacy_params or current['credential_type'] == 'iam_user':
+            for param in FORBIDDEN_IF_IAM_USER:
+                # hvac returns these as int(0)
+                # however the argspec default must be None since the argspec
+                # type is a string, and "0" will cause create_or_update_role to choke
+                # so it's easier just to fix this up before comparing
+                current[param] = None
+
+        changed = current != desired_state
+    else:
+        changed = True
+
+    # make the changes!
+    if changed:
+        diff_header = '/'.join([mount_point, 'roles', name])
+        diff = dict(after=dict(**desired_state), # make a copy, since we modify this later
+                    after_header=diff_header)
+        credential_type = desired_state.pop('credential_type').split(',')[0]
+        if not module.check_mode:
+            client.secrets.aws.create_or_update_role(name, credential_type,
+                                                     mount_point=mount_point,
+                                                     legacy_params=legacy_params,
+                                                     **desired_state)
+        if existing:
+            diff.update(before=current, before_header=diff_header)
+        else:
+            diff.update(before='', before_header='(absent)')
+        return {'changed': changed, 'diff': diff}
+
+    return {'changed': changed}
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/modules/hashivault/hashivault_k8s_auth_config.py
+++ b/ansible/modules/hashivault/hashivault_k8s_auth_config.py
@@ -99,7 +99,15 @@ def hashivault_k8s_auth_config(module):
 
     if not module.check_mode:
         client.auth.kubernetes.configure(**desired_state)
-    return {'changed': True, 'keys_updated': keys_updated}
+
+    diff_header='/'.join(['auth', mount_point, 'config'])
+    diff = dict(
+        before=current_state,
+        before_header=diff_header,
+        after={k: v for k, v in desired_state.iteritems() if k not in ignore_list},
+        after_header=diff_header,
+    )
+    return {'changed': True, 'keys_updated': keys_updated, 'diff': diff}
 
 
 if __name__ == '__main__':

--- a/ansible/modules/hashivault/hashivault_ldap_group_list.py
+++ b/ansible/modules/hashivault/hashivault_ldap_group_list.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+from ansible.module_utils.hashivault import hashivault_argspec
+from ansible.module_utils.hashivault import hashivault_auth_client
+from ansible.module_utils.hashivault import hashivault_init
+from ansible.module_utils.hashivault import hashiwrapper
+from hvac.exceptions import InvalidPath
+
+ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
+DOCUMENTATION = '''
+---
+module: hashivault_ldap_group_list
+version_added: "pure_ci-1.0.0"
+short_description: Hashicorp Vault ldap_group list module
+description:
+    - Module to list ldap groups in Hashicorp Vault.
+extends_documentation_fragment: hashivault
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_ldap_group_list:
+      register: 'vault_ldap_group_list'
+    - debug: msg="Policies are {{vault_ldap_group_list.ldap_groups}}"
+'''
+
+
+def main():
+    argspec = hashivault_argspec()
+    module = hashivault_init(argspec)
+    result = hashivault_ldap_group_list(module.params)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+@hashiwrapper
+def hashivault_ldap_group_list(params):
+    client = hashivault_auth_client(params)
+    try:
+        groups = client.auth.ldap.list_groups().get('data', {}).get('keys', [])
+    except InvalidPath:
+        # treat as empty -- this caters to running this in check mode on a fresh install of Vault
+        # where the tasks to enable ldap auth may be running in check mode as well
+        groups = []
+    return {'ldap_groups': groups}
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/modules/hashivault/hashivault_ldap_user.py
+++ b/ansible/modules/hashivault/hashivault_ldap_user.py
@@ -8,11 +8,11 @@ from hvac.exceptions import InvalidPath
 ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
 DOCUMENTATION = '''
 ---
-module: hashivault_ldap_group
-version_added: "3.18.3"
-short_description: Hashicorp Vault LDAP group configuration module
+module: hashivault_ldap_user
+version_added: "pure_ci-1.0.0"
+short_description: Hashicorp Vault LDAP user configuration module
 description:
-    - Module to configure LDAP groups in Hashicorp Vault.
+    - Module to configure LDAP users in Hashicorp Vault.
 options:
     mount_point:
         description:
@@ -20,11 +20,11 @@ options:
         default: ldap
     name:
         description:
-            - name of the group
+            - name of the user
         default: None
     policies:
         description:
-            - policies to be tied to the group
+            - policies to be tied to the user
         default: None
     state:
         description:
@@ -35,8 +35,8 @@ EXAMPLES = '''
 ---
 - hosts: localhost
   tasks:
-    - hashivault_ldap_group:
-        name: 'my-group'
+    - hashivault_ldap_user:
+        name: 'some-user'
         policies:
             - 'my-policy'
         token: "{{ vault_token }}"
@@ -46,42 +46,56 @@ EXAMPLES = '''
 
 def main():
     argspec = hashivault_argspec()
+    argspec['groups'] = dict(required=False, type='list', default=[])
     argspec['name'] = dict(required=True, type='str', default=None)
     argspec['mount_point'] = dict(required=False, type='str', default='ldap')
     argspec['policies'] = dict(required=False, type='list', default=[])
     argspec['state'] = dict(required=False, choices=['present', 'absent'], default='present')
     module = hashivault_init(argspec, supports_check_mode=True)
-    result = hashivault_ldap_group(module)
+    result = hashivault_ldap_user(module)
     if result.get('failed'):
         module.fail_json(**result)
     else:
         module.exit_json(**result)
 
 
-def hashivault_ldap_group_update(group_details, client, group_name, group_policies, mount_point, check_mode=False):
+def _diff_object(groups, **kwargs):
+    return dict(groups=','.join(sorted(groups)), **kwargs)
+
+
+def hashivault_ldap_user_update(user_details, client, user_name, user_groups, user_policies, mount_point, check_mode=False):
     changed = False
 
+    # existing groups
+    if user_details['groups'] is not None:
+        if set(user_details['groups']) != set(user_groups):
+            changed = True
+    # new groups and none existing
+    elif len(user_groups) > 0:
+        changed = True
+
     # existing policies
-    if group_details['policies'] is not None:
-        if set(group_details['policies']) != set(group_policies):
+    if user_details['policies'] is not None:
+        if set(user_details['policies']) != set(user_policies):
             changed = True
     # new policies and none existing
-    elif len(group_policies) > 0:
+    elif len(user_policies) > 0:
         changed = True
 
     if changed:
-        header = '/'.join(['auth', mount_point, 'groups', group_name])
+        header = '/'.join(['auth', mount_point, 'users', user_name])
         diff = dict(
-            before=dict(policies=group_details['policies']),
+            before=_diff_object(groups=user_details['groups'], policies=user_details['policies']),
             before_header=header,
-            after=dict(policies=group_policies),
+            after=_diff_object(groups=user_groups, policies=user_policies),
             after_header=header,
         )
         if not check_mode:
             try:
-                response = client.auth.ldap.create_or_update_group(
-                    name=group_name,
-                    policies=group_policies,
+                response = client.auth.ldap.create_or_update_user(
+                    username=user_name,
+                    groups=user_groups,
+                    policies=user_policies,
                     mount_point=mount_point
                 )
             except Exception as e:
@@ -92,59 +106,62 @@ def hashivault_ldap_group_update(group_details, client, group_name, group_polici
     return {'changed': False}
 
 
-def hashivault_ldap_group_create_or_update(module):
+def hashivault_ldap_user_create_or_update(module):
     params = module.params
     client = hashivault_auth_client(params)
-    group_name = params.get('name')
+    user_name = params.get('name')
     mount_point = params.get('mount_point')
-    group_policies = params.get('policies')
+    user_groups = params.get('groups')
+    user_policies = params.get('policies')
     try:
-        group_details = client.auth.ldap.read_group(name=group_name, mount_point=mount_point)
+        user_details = client.auth.ldap.read_user(username=user_name, mount_point=mount_point)
     except InvalidPath:
-        group_details = None
+        user_details = None
 
-    if group_details is None:
+    if user_details is None:
         diff = dict(
             before='',
             before_header='(absent)',
-            after=dict(policies=group_policies),
-            after_header='/'.join(['auth', mount_point, 'groups', group_name]),
+            after=_diff_object(groups=user_groups, policies=user_policies),
+            after_header='/'.join(['auth', mount_point, 'users', user_name]),
         )
         if not module.check_mode:
-            client.auth.ldap.create_or_update_group(
-                name=group_name,
-                policies=group_policies,
+            client.auth.ldap.create_or_update_user(
+                username=user_name,
+                groups=user_groups,
+                policies=user_policies,
                 mount_point=mount_point
             )
         return {'changed': True, 'diff': diff}
-    return hashivault_ldap_group_update(group_details['data'], client, group_name=group_name,
-                                        group_policies=group_policies,
-                                        check_mode=module.check_mode,
-                                        mount_point=mount_point)
+    return hashivault_ldap_user_update(user_details['data'], client, user_name=user_name,
+                                       user_groups=user_groups,
+                                       user_policies=user_policies,
+                                       check_mode=module.check_mode,
+                                       mount_point=mount_point)
 
 
-def hashivault_ldap_group_delete(module):
+def hashivault_ldap_user_delete(module):
     params = module.params
     client = hashivault_auth_client(params)
-    group_name = params.get('name')
+    user_name = params.get('name')
 
     try:
-        client.auth.ldap.read_group(name=group_name)
+        client.auth.ldap.read_user(username=user_name)
     except InvalidPath:
         return {'changed': False}
     if not module.check_mode:
-        client.auth.ldap.delete_group(name=group_name)
+        client.auth.ldap.delete_user(username=user_name)
     return {'changed': True}
 
 
 @hashiwrapper
-def hashivault_ldap_group(module):
+def hashivault_ldap_user(module):
     params = module.params
     state = params.get('state')
     if state == 'present':
-        return hashivault_ldap_group_create_or_update(module)
+        return hashivault_ldap_user_create_or_update(module)
     elif state == 'absent':
-        return hashivault_ldap_group_delete(module)
+        return hashivault_ldap_user_delete(module)
 
 
 if __name__ == '__main__':

--- a/ansible/modules/hashivault/hashivault_ldap_user_list.py
+++ b/ansible/modules/hashivault/hashivault_ldap_user_list.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+from ansible.module_utils.hashivault import hashivault_argspec
+from ansible.module_utils.hashivault import hashivault_auth_client
+from ansible.module_utils.hashivault import hashivault_init
+from ansible.module_utils.hashivault import hashiwrapper
+from hvac.exceptions import InvalidPath
+
+ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
+DOCUMENTATION = '''
+---
+module: hashivault_ldap_user_list
+version_added: "pure_ci-1.0.0"
+short_description: Hashicorp Vault ldap_user list module
+description:
+    - Module to list ldap users in Hashicorp Vault.
+extends_documentation_fragment: hashivault
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_ldap_user_list:
+      register: 'vault_ldap_user_list'
+    - debug: msg="Policies are {{vault_ldap_user_list.ldap_users}}"
+'''
+
+
+def main():
+    argspec = hashivault_argspec()
+    module = hashivault_init(argspec)
+    result = hashivault_ldap_user_list(module.params)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+@hashiwrapper
+def hashivault_ldap_user_list(params):
+    client = hashivault_auth_client(params)
+    try:
+        users = client.auth.ldap.list_users().get('data', {}).get('keys', [])
+    except InvalidPath:
+        # treat as empty -- this caters to running this in check mode on a fresh install of Vault
+        # where the tasks to enable ldap auth may be running in check mode as well
+        users = []
+    return {'ldap_users': users}
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/modules/hashivault/hashivault_userpass_list.py
+++ b/ansible/modules/hashivault/hashivault_userpass_list.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+from ansible.module_utils.hashivault import hashivault_argspec
+from ansible.module_utils.hashivault import hashivault_auth_client
+from ansible.module_utils.hashivault import hashivault_init
+from ansible.module_utils.hashivault import hashiwrapper
+from hvac.exceptions import InvalidPath
+
+ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
+DOCUMENTATION = '''
+---
+module: hashivault_userpass_list
+version_added: "pure_ci-1.0.0"
+short_description: Hashicorp Vault userpass list module
+description:
+    - Module to list auth/userpass/users in Hashicorp Vault.
+options:
+extends_documentation_fragment: hashivault
+    mount_point:
+        description:
+            - name of the auth mount name
+        default: userpass
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_userpass_list:
+      register: 'vault_userpass_list'
+    - debug: msg="Policies are {{vault_userpass_list.users}}"
+'''
+
+
+def main():
+    argspec = hashivault_argspec()
+    argspec['mount_point'] = dict(required=False, type='str', default='userpass')
+    module = hashivault_init(argspec)
+    result = hashivault_userpass_list(module.params)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+@hashiwrapper
+def hashivault_userpass_list(params):
+    client = hashivault_auth_client(params)
+    mount_point = params.get('mount_point').strip('/')
+    try:
+        current_users = client.auth.userpass.list_user(mount_point)['data']['keys']
+    except InvalidPath:
+        # treat as empty -- this caters to running this in check mode on a fresh install of Vault
+        # where the tasks to enable userpass auth may be running in check mode as well
+        current_users = []
+    return {'users': current_users}
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- hashivault_auth_ldap.py
- hashivault_auth_method.py
- hashivault_k8s_auth_config.py
- hashivault_ldap_group.py
- hashivault_policy.py
- hashivault_secret_engine.py
- hashivault_userpass.py

additional notes:

- hashivault_userpass.py now uses new hvac client.auth.userpass methods,
instead of methods directly on the client object that will be deprecated
in hvac 1.0.0.

- hashivault_auth_ldap.py remove spurious parameters token_ttl and
token_max_ttl, which are not returned by the API (or apparently consumed
by them either), so don't include them in current/desired state or
args processing.

add new modules:

- hashivault_aws_secret_engine_{config,role}.py
- hashivault_ldap_{group,user}_list.py
- hashivault_ldap_user.py
- hashivault_userpass_list.py

additional notes:

- hashivault_aws_secret_engine_role.py supports legacy_params mode in
which hvac/Vault only pays attention to policy_document/policy_arns and
other parameters are ignored; on write the legacy format is converted
into the current role structure, in so doing setting credential_types to
[iam_user, federation_token].